### PR TITLE
feat: set up custom cache directory

### DIFF
--- a/src/app/api/pipeline.js
+++ b/src/app/api/pipeline.js
@@ -1,5 +1,7 @@
 import { pipeline } from "@xenova/transformers";
 
+process.env.CACHE_DIR = '/tmp';
+
 class PipelineSingleton {
   static task = 'feature-extraction';
   static model = 'Xenova/all-MiniLM-L6-v2';


### PR DESCRIPTION
#### *Description*
This PR fixes the caching issue in the Vercel deployment by configuring the `@xenova/transformers` library to use the `/tmp` directory for caching. This resolves the `ENOENT` error that occurs when the library attempts to create or access the `/vercel` directory.

#### **Changes**
Updated `pipeline.js` to set the cache directory to `/tmp`:

javascript
```
process.env.CACHE_DIR = '/tmp';
```
Ensured the embedding pipeline uses the writable /tmp directory in the serverless environment.

#### **Testing**
Local Testing: Verified that the embedding pipeline works correctly with the /tmp cache directory.

Vercel Deployment: Deployed the changes to Vercel and confirmed that the chatbot responds to queries without errors.

Related Issue
Fixes #15 

#### **Notes**
This change ensures compatibility with serverless environments like Vercel by using the writable /tmp directory for caching.

No additional dependencies or configuration changes are required.